### PR TITLE
feat: 独立お気に入りボタンで解除ができるようにした

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -83,11 +83,11 @@
 				<button v-if="appearNote.myReaction != null" ref="reactButton" class="button _button reacted" @click="undoReact(appearNote)">
 					<i class="ti ti-minus"></i>
 				</button>
+				<button v-if="$store.reactiveState.UseIsolatedfav.value" ref="favButton" class="button _button" :class="{ reacted: isFavorited }" @click="toggleFavorite()">
+					<i class="ti" :class="{ 'ti-star': !isFavorited, 'ti-star-filled': isFavorited }"></i>
+				</button>
 				<button ref="menuButton" class="button _button" @click="menu()">
 					<i class="ti ti-dots"></i>
-				</button>
-				<button v-if="$store.reactiveState.UseIsolatedfav.value" ref="favButton" class="button _button" @mousedown="toggleFavorite(true)">
-					<i class="ti ti-star"></i>
 				</button>
 			</footer>
 		</div>
@@ -185,11 +185,19 @@ const translation = ref(null);
 const translating = ref(false);
 const urls = appearNote.text ? extractUrlFromMfm(mfm.parse(appearNote.text)) : null;
 const showTicker = (defaultStore.state.instanceTicker === 'always') || (defaultStore.state.instanceTicker === 'remote' && appearNote.user.instance);
-function toggleFavorite(favorite: boolean): void {
-	os.apiWithDialog(favorite ? 'notes/favorites/create' : 'notes/favorites/delete', {
+const isFavorited = ref(false);
+
+onMounted(async (): Promise<void> => {
+	const noteState = await os.api('notes/state', { noteId: appearNote.id }) as { isFavorited: boolean, isWatching: boolean, isMutedThread: boolean };
+	isFavorited.value = noteState.isFavorited;
+});
+
+const toggleFavorite = (): void => {
+	isFavorited.value = !isFavorited.value;
+	os.apiWithDialog(isFavorited.value ? 'notes/favorites/create' : 'notes/favorites/delete', {
 		noteId: appearNote.id,
 	});
-}
+};
 
 const keymap = {
 	'r': () => reply(true),

--- a/packages/client/src/scripts/get-note-menu.ts
+++ b/packages/client/src/scripts/get-note-menu.ts
@@ -182,7 +182,7 @@ export function getNoteMenu(props: {
 				text: i18n.ts.translate,
 				action: translate,
 			} : undefined,
-			null,
+			UseIsolatedfav.value ? undefined : null,
 			statePromise.then(state => {
 				if (UseIsolatedfav.value) {
 					return null;


### PR DESCRIPTION
# What
- 独立お気に入りボタンで解除ができるようにした
- 独立お気に入りボタン仕様時にノートのメニューに2重線が表示される不具合を修正

# Additional info (optional)
独立お気に入りボタン無効状態でお気に入りに入れる/外す→設定から独立お気に入りボタンを有効化→TLに戻る
を行なうと独立お気に入りボタンの見た目がお気に入りの状態と一致しないバグ有り
設定変更時にリロードを強制すれば回避可能
